### PR TITLE
fixed name of 'Bloons TD 6'

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@
         <img src="./resources/bloons.png" draggable="false" />
 
         <div class="game-text">
-          <h2 class="game-title">Bloons Tower Defense 6</h2>
+          <h2 class="game-title">Bloons TD 6</h2>
           <p>
-            Bloons Tower Defense 6 is a tower defense game where the goal it to pop all of
+            Bloons TD 6 is a tower defense game where the goal it to pop all of
             the bloons get generated, if you don't pop some of the bloons you
             die.
           </p>


### PR DESCRIPTION
Due to ~~stupid~~ copyright on the "tower defense" branding the name of the video game being described in the changed section is actually "bloons TD 6"
